### PR TITLE
Remove package main

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -150,3 +150,14 @@ My approach will differ slightly from basscss, in that the directory structure w
       - create build scripts for unminified and minified versions
         - the main diff between the two is [normalizeWhitespace](https://cssnano.co/optimisations/normalizewhitespace)
         - other normal cssnano optimizations that are disabled are `mergeLonghand` and `mergeRules`, so that all rules are completely functionaly similar to their sources
+
+## 7. Remove `main` field in package.json to fix bug when installing palette.css
+
+- starting point: v0.3.0
+- ending point: v0.3.1
+- branch: remove-package-main
+
+I got a postcss error after installing v0.3.0 in zelip.me. I thought the problem might be [`browser` vs `main` fields](https://parceljs.org/module_resolution.html#package.json-%60browser%60-field). But no - the same problem existed when using [`browser` field](https://docs.npmjs.com/files/package.json#browser). Basscss v7.1.1 did not have a `main` or `browser` field. I think this is the key.
+
+- steps:
+  - remove the `main` field entirely from package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "palette.css",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "palette.css",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Atomic CSS library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "functional css",
     "OOCSS"
   ],
-  "main": "dist/palette.min.css",
   "scripts": {
     "build": "npm run build:unminified && npm run build:minified",
     "build:unminified": "NODE_ENV=unminified postcss src/palette.css -d dist",


### PR DESCRIPTION
This PR fixes a postcss build error that occurred after installing v0.3.0 in zelip.me.

### about the postcss error

When I deleted the postcss.config.js file in node_modules/palette.css, the error went away. I started reading in the parceljs docs and the npm docs, and found the following (in order):

1. Parcel: [package.json browser field](https://parceljs.org/module_resolution.html#package.json-%60browser%60-field)
2. npm: [browser field](https://docs.npmjs.com/files/package.json#browser)

This error persisted with this package metadata change.

So then I looked at [Basscss v7.1.1](https://github.com/basscss/basscss/blob/a07f9e5eceed0df3fc638ef99559f7decf63aad1/package.json) and learned that he didn't have a `main` or `browser` field in his package.json, although he did have a postcss.config.js file.

So the solution forward seems to be, DELETE `package.main`!