### PR TITLE
Add `package.files` and `package.main`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -161,3 +161,20 @@ I got a postcss error after installing v0.3.0 in zelip.me. I thought the problem
 
 - steps:
   - remove the `main` field entirely from package.json
+
+## 8. Use `files` field in package.json to fix parcel build error in a project that depends on palette.css
+
+- starting point: v0.3.1
+- ending point: v0.3.2
+- branch: package.files
+- steps:
+  - Add `files` field to package.json, including dist/\*.css
+  - Add `main` field denoting dist/palette.min.css
+
+The postcss error from v0.3.1 above still happens after deleting `package.main`. My current package.json set up seems to mirror [Basscss v7.1.1](https://github.com/basscss/basscss/blob/a07f9e5eceed0df3fc638ef99559f7decf63aad1/package.json) in that he has no `main` or `browser` fields. He does have a `style` field, but that is not conventional, and likely plays no part in there not being an error when I depend on basscss.
+
+I did read [this !so answer](https://stackoverflow.com/a/40375125/2145103) however, which suggests using the `files` field - "This way you'll end up with just the files you need in npm registry".
+
+See the package.json [`files` field docs](https://docs.npmjs.com/files/package.json#files).
+
+Let's try it out!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "palette.css",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "files": [
     "dist/*.css"
   ],
+  "main": "dist/palette.min.css",
   "scripts": {
     "build": "npm run build:unminified && npm run build:minified",
     "build:unminified": "NODE_ENV=unminified postcss src/palette.css -d dist",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "OOCSS"
   ],
   "files": [
-    "dist/*.css"
+    "dist/palette.css",
+    "dist/palette.min.css"
   ],
   "main": "dist/palette.min.css",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "palette.css",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Atomic CSS library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "functional css",
     "OOCSS"
   ],
+  "files": [
+    "dist/*.css"
+  ],
   "scripts": {
     "build": "npm run build:unminified && npm run build:minified",
     "build:unminified": "NODE_ENV=unminified postcss src/palette.css -d dist",


### PR DESCRIPTION
This PR adds a `files` array to package.json, as well as re-adds a `main` field.

See [this !so answer](https://stackoverflow.com/a/40375125/2145103) which helped me in this regard.

I'm not sure if it will work until published to npm so I can install it normally in zelip.me, let's hope so!