### PR TITLE
Wtf parcel postcss

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -204,3 +204,13 @@ I practiced with it a bunch, just to try to see the rediculousness of the error 
   ```
 - steps:
   - get rid of `package.files`
+
+## 10. WTF PARCEL POSTCSS?!?!
+
+Summary: _redoing_ work from entry number 8 above 🤔. **WTF** parcel postcss build?!?!?!?
+
+- starting point: v0.3.3
+- ending point: v0.3.4
+- branch: wtf-parcel-postcss
+- steps:
+  - Add `files` array to package.json, keep dist/\*.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "palette.css",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "OOCSS"
   ],
   "main": "dist/palette.min.css",
+  "files": [
+    "dist/palette.css",
+    "dist/palette.min.css"
+  ],
   "scripts": {
     "build": "npm run build:unminified && npm run build:minified",
     "build:unminified": "NODE_ENV=unminified postcss src/palette.css -d dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "palette.css",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Atomic CSS library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR re-adds `package.files` to (temporarily) get around the parcel postcss build error when importing the entire palette.css repo.

Closes #11 